### PR TITLE
Fix UI for results-incorrect page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -29,6 +29,7 @@ embed, img, object, video {
 
 .img-results {
     border: 1px solid rgba(0,0,0,.1);
+    width: 491px;
 }
 
 .interval-limit {
@@ -85,6 +86,15 @@ embed, img, object, video {
   content: 'Marius Mucenicu had something to do with this website.';
 }
 
+.table-results {
+    max-width: 491px;
+}
+
+.table-results td,
+.table-results th {
+    font-size: 1.5rem;
+}
+
 .text-status-code {
     margin-top: 1rem;
     margin-bottom: 2rem;
@@ -120,6 +130,11 @@ embed, img, object, video {
     #interval-data h1 {
         font-size: 1.1rem;
     }
+
+    .table-results td,
+    .table-results th {
+        font-size: 1.25rem;
+    }
 }
 
 @media only screen and (min-width: 360px) and (max-width:470px) {
@@ -137,6 +152,11 @@ embed, img, object, video {
     .btn-answer-quit {
         float: left;
         width: 230.5px;
+    }
+
+    .table-results td,
+    .table-results th {
+        font-size: 1.75rem;
     }
 }
 

--- a/templates/result_failure.html
+++ b/templates/result_failure.html
@@ -4,39 +4,63 @@ $var title: Failure
 <div class="col-12">
   <div class="row text-center">
       <div class="col-12">
-        <h1><span class="result-incorrect text-uppercase">Incorrect!</span></h1>
+        <h1 class="result-incorrect text-uppercase">Incorrect!</h1>
       </div>
   </div>
   <div class="row">
     <div class="col-12">
-        <ul>
-          <li>
-            Interval: <strong>$data['left_glyph']<span>$data['start_representation']</span>,
-            <span>$data['stop_representation']</span>$data['right_glyph']</strong>
-          </li>
-          <li>
-            Your answer: <strong class="result-incorrect">$data['answer_representation']</strong>
-          </li>
-          <li>
-            Correct answer: <strong class="result-correct">$data['cpu_representation']</strong>
-          </li>
-        </ul>
       <hr>
     </div>
   </div>
   <div class="row" align="center">
     <div class="col-12">
-      <img src="/static/images/giphyFailure.webp" class="img-fluid" alt="GIFFY">
+      <img src="/static/images/giphyFailure.webp" class="img-fluid img-results" alt="GIFFY">
     </div>
   </div>
   <div class="row">
-    <div class="col-12 text-center">
+    <div class="col-12">
+      <hr>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <div class="table-responsive table-results mx-auto">
+        <table class="table table-sm table-bordered text-center">
+          <tr>
+            <th class="table-active">Interval</th>
+          </tr>
+          <tr>
+            <td>$data['left_glyph']$data['start_representation'],
+                $data['stop_representation']$data['right_glyph']</td>
+          </tr>
+          <tr>
+            <th class="table-danger">Your answer</th>
+          </tr>
+          <tr>
+            <td>$data['answer_representation']</td>
+          </tr>
+          <tr>
+            <tr>
+              <th class="table-success">Correct answer</th>
+            </tr>
+          </tr>
+          <tr>
+            <td>$data['cpu_representation']</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-sm-6 mb-3">
       <form action="/play" method="POST">
-        <button class="btn btn-danger btn-answer" type="submit"
-                name="level" value="$data['game_level']">Next question
-        </button>
-        <a href="https://www.google.com/" class="btn btn-danger">I'm done for today</a>
+        <button class="btn btn-answer-next btn-block btn-danger" type="submit"
+                name="level" value="$data['game_level']">Next question</button>
       </form>
+    </div>
+    <div class="col-12 col-sm-6 mb-3">
+      <a href="https://www.google.com/"
+         class="btn btn-answer-quit btn-block btn-danger">I'm done for today</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #11

- Changed layout (now image is before the results)
- Made buttons responsive by adding different behavior at different breakpoints
- Replaced the results list with a responsive table and because of the vertical positioning even the largest numbers don't wrap (this can be improved with JS to make it use a horizontal table flow on wide screens and use column drop pattern on the smallest screens but that's more of a mood than a requirement)