### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,31 +2,39 @@
 Encapsulates o series of interactive games with the purpose of increasing one's mood.
 
 <table>
-    <tr>
-        <th rowspan="3">Tests</th>
-        <th>Branch</th>
-        <th>Status</th>
-    </tr>
-    <tr>
-        <td>Master</td>
-        <td><img src="https://travis-ci.com/mariusmucenicu/mind-games.svg?branch=master"></td>
-    </tr>
-    <tr>
-        <td>Staging</td>
-        <td><img src="https://travis-ci.com/mariusmucenicu/mind-games.svg?branch=staging"</td>
-    </tr>
-    <tr>
-        <th>To do</th>
-        <td colspan="2" align="center">
-            <img src="https://img.shields.io/github/issues/mariusmucenicu/mind-games.svg">
-        </td>
-    </tr>
-    <tr>
-        <th>State</th>
-        <td colspan="2" align="center">
-            <img src="https://img.shields.io/github/commits-since/mariusmucenicu/mind-games/0.1.0.svg">
-        </td>
-    </tr>
+  <tr>
+    <th rowspan="3">Tests</th>
+    <th>Branch</th>
+    <th>Status</th>
+  </tr>
+  <tr>
+    <td>Master</td>
+    <td>
+      <a href="https://travis-ci.com/mariusmucenicu/mind-games/branches">
+        <img src="https://travis-ci.com/mariusmucenicu/mind-games.svg?branch=master"></a>
+    </td>
+  </tr>
+  <tr>
+    <td>Staging</td>
+    <td>
+      <a href="https://travis-ci.com/mariusmucenicu/mind-games/branches">
+        <img src="https://travis-ci.com/mariusmucenicu/mind-games.svg?branch=staging"></a>
+    </td>
+  </tr>
+  <tr>
+    <th>To do</th>
+    <td colspan="2" align="center">
+      <a href="https://github.com/mariusmucenicu/mind-games/issues">
+        <img src="https://img.shields.io/github/issues/mariusmucenicu/mind-games.svg"></a>
+    </td>
+  </tr>
+  <tr>
+    <th>State</th>
+    <td colspan="2" align="center">
+      <a href="https://github.com/mariusmucenicu/mind-games/compare/0.1.0...master">
+        <img src="https://img.shields.io/github/commits-since/mariusmucenicu/mind-games/0.1.0.svg"></a>
+    </td>
+  </tr>
 </table>
 
 ## Contents


### PR DESCRIPTION
Fixes #34

- Added links for each of the status badge in the README.md
- Previously there links were straight to the .svg (which did display correctly since in turn that domain which provides the images does requests to find out the state of the repo / builds) however, we wanted links straight to the source, which is a lot more convenient.