### PR TITLE
fix: Use height instead of min-height for container

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -15,7 +15,7 @@ embed, img, object, video {
 
 .container-fluid {
   background-color: rgb(255,255,255);
-  min-height: 100%;
+  height: 100%;
   max-width: 960px;
   overflow: auto;
 }


### PR DESCRIPTION
This gives us the advantage of setting an explicit height for the container, and therefor we can use
relative length units for children of container.